### PR TITLE
Do not show on fast Ctrl-Tab avoiding unnecessary flickering of windo…

### DIFF
--- a/Source/CtrlTab.FrmOpenDocs.pas
+++ b/Source/CtrlTab.FrmOpenDocs.pas
@@ -161,7 +161,7 @@ begin
   end
   else if (Key = VK_TAB) or (Key = VK_SPACE) then
   begin
-    AlphaBlendValue := 255;
+    AlphaBlend := False;
     FTabKeyUpCalled := True;
 
     // if shift is pressed move the opposite direction

--- a/Source/CtrlTab.FrmOpenDocs.pas
+++ b/Source/CtrlTab.FrmOpenDocs.pas
@@ -105,6 +105,8 @@ var
   FileDisplayName: string;
   i: Integer;
 begin
+  AlphaBlend := True;
+  AlphaBlendValue := 0;
   FIsShowing := True;
   FTabKeyUpCalled := False;
 
@@ -159,6 +161,7 @@ begin
   end
   else if (Key = VK_TAB) or (Key = VK_SPACE) then
   begin
+    AlphaBlendValue := 255;
     FTabKeyUpCalled := True;
 
     // if shift is pressed move the opposite direction


### PR DESCRIPTION
Just a quick tweak to avoid unnecessary window show flickering when we want to switch fastly to another tab, I guess there is no need to show the window unless TAB key is up on form to navigate the list. I know that it still "shows" but invisible.